### PR TITLE
bitbang-hal updates

### DIFF
--- a/examples/spi.rs
+++ b/examples/spi.rs
@@ -5,14 +5,15 @@
 use panic_halt;
 
 use metro_m4 as hal;
-use embedded_hal;
 use hal::clock::GenericClockController;
 use hal::delay::Delay;
 use hal::prelude::*;
 use hal::{entry, CorePeripherals, Peripherals};
 use hal::timer::TimerCounter;
 use nb::block;
-use bitbang_hal;
+
+use bitbang_hal::spi::SPI;
+use bitbang_hal::spi::MODE_0;
 
 #[entry]
 fn main() -> ! {
@@ -39,12 +40,7 @@ fn main() -> ! {
     let mosi = pins.mosi.into_push_pull_output(&mut pins.port);
     let sck = pins.sck.into_push_pull_output(&mut pins.port);
 
-    let mode = embedded_hal::spi::Mode {
-        polarity: embedded_hal::spi::Polarity::IdleLow,
-        phase: embedded_hal::spi::Phase::CaptureOnFirstTransition,
-    };
-    let mut spi = bitbang_hal::spi::SPI::new(mode, miso, mosi, sck, timer);
-
+    let mut spi = SPI::new(MODE_0, miso, mosi, sck, timer);
     let mut delay = Delay::new(core.SYST, &mut clocks);
 
     loop {

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -1,3 +1,5 @@
+pub use embedded_hal::spi::{MODE_0, MODE_1, MODE_2, MODE_3};
+
 use embedded_hal::spi::{FullDuplex, Mode, Phase::*, Polarity::*};
 use embedded_hal::digital::{InputPin, OutputPin};
 use embedded_hal::timer::{CountDown, Periodic};


### PR DESCRIPTION
Hi @sajattack  and all,

Here is a patch series with misc updates for bitbang-hal.
Functional changes include:
- enable support for both LSB first and FSB first bit order
Other changes include:
- re-export MODE_* from embedded-hal to simplify using of bitbang-hal
- use match for SPI modes to improve code readability

Besides, spi example is updated according to suggested changes.

Regards,
Sergey