### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,10 @@ keywords = ["no_std", "embedded", "bitbang", "embedded-hal", "hal"]
 categories = ["embedded", "no-std"]
 
 [dependencies]
-nb = "~0.1"
+nb = "0.1"
 
 [dependencies.embedded-hal]
-version = "~0.2"
+version = "0.2.3"
 features = ["unproven"]
 
 [dev-dependencies.stm32f1xx-hal]


### PR DESCRIPTION
The `digital::v2` needs at least `embedded-hal` `0.2.3`.
This also specifies the dependencies using standard semver.