### PR TITLE
Fix writing empty buffer

### DIFF
--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -243,10 +243,6 @@ where
     type Error = crate::i2c::Error<E>;
 
     fn write(&mut self, addr: u8, output: &[u8]) -> Result<(), Self::Error> {
-        if output.is_empty() {
-            return Ok(());
-        }
-
         // ST
         self.i2c_start()?;
 


### PR DESCRIPTION
As seen in the [stm32f0 embedded hal i2c_find_addresses example](https://github.com/stm32-rs/stm32f0xx-hal/blob/fba9834b59fa7567ffd604afed2bcd8d07c4e904/examples/i2c_find_address.rs#L36), writing an empty buffer to a certain address with the write bit active and checking the ACK can be used to check if a device is present at this address.
With this change, scanning the bus works flawlessly.

Writing just a write to an address is also sometimes used to check if a device has woken up (like here: https://github.com/barafael/sdp8xx/blob/0e2ff653d0309866412b37a413261adeeac977f7/src/lib.rs#L256)

The same thing is also required for writing QuickCommands. Though this might be specific to SMBus :)

I hope this doesn't break anything else (?).

Thanks for the great library!