### PR TITLE
expose low-level i2c control for not-quite-i2c devices

### DIFF
--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -94,7 +94,7 @@ where
     /// **This is a low-level control function.** For normal I2C devices,
     /// please use the embedded-hal traits [Read], [Write], or
     /// [WriteRead].
-    pub fn i2c_start(&mut self) -> Result<(), crate::i2c::Error<E>> {
+    pub fn raw_i2c_start(&mut self) -> Result<(), crate::i2c::Error<E>> {
         self.set_scl_high()?;
         self.set_sda_high()?;
         self.wait_for_clk();
@@ -113,7 +113,7 @@ where
     /// **This is a low-level control function.** For normal I2C devices,
     /// please use the embedded-hal traits [Read], [Write], or
     /// [WriteRead].
-    pub fn i2c_stop(&mut self) -> Result<(), crate::i2c::Error<E>> {
+    pub fn raw_i2c_stop(&mut self) -> Result<(), crate::i2c::Error<E>> {
         self.set_scl_high()?;
         self.wait_for_clk();
 
@@ -197,7 +197,7 @@ where
     /// please use the embedded-hal traits [Read], [Write], or
     /// [WriteRead].
     #[inline]
-    pub fn read_from_slave(&mut self, input: &mut [u8]) -> Result<(), crate::i2c::Error<E>> {
+    pub fn raw_read_from_slave(&mut self, input: &mut [u8]) -> Result<(), crate::i2c::Error<E>> {
         for i in 0..input.len() {
             let should_send_ack = i != (input.len() - 1);
             input[i] = self.i2c_read_byte(should_send_ack)?;
@@ -211,7 +211,7 @@ where
     /// please use the embedded-hal traits [Read], [Write], or
     /// [WriteRead].
     #[inline]
-    pub fn write_to_slave(&mut self, output: &[u8]) -> Result<(), crate::i2c::Error<E>> {
+    pub fn raw_write_to_slave(&mut self, output: &[u8]) -> Result<(), crate::i2c::Error<E>> {
         for byte in output {
             self.i2c_write_byte(*byte)?;
             self.check_ack()?;
@@ -264,16 +264,16 @@ where
 
     fn write(&mut self, addr: u8, output: &[u8]) -> Result<(), Self::Error> {
         // ST
-        self.i2c_start()?;
+        self.raw_i2c_start()?;
 
         // SAD + W
         self.i2c_write_byte((addr << 1) | 0x0)?;
         self.check_ack()?;
 
-        self.write_to_slave(output)?;
+        self.raw_write_to_slave(output)?;
 
         // SP
-        self.i2c_stop()
+        self.raw_i2c_stop()
     }
 }
 
@@ -291,16 +291,16 @@ where
         }
 
         // ST
-        self.i2c_start()?;
+        self.raw_i2c_start()?;
 
         // SAD + R
         self.i2c_write_byte((addr << 1) | 0x1)?;
         self.check_ack()?;
 
-        self.read_from_slave(input)?;
+        self.raw_read_from_slave(input)?;
 
         // SP
-        self.i2c_stop()
+        self.raw_i2c_stop()
     }
 }
 
@@ -318,24 +318,24 @@ where
         }
 
         // ST
-        self.i2c_start()?;
+        self.raw_i2c_start()?;
 
         // SAD + W
         self.i2c_write_byte((addr << 1) | 0x0)?;
         self.check_ack()?;
 
-        self.write_to_slave(output)?;
+        self.raw_write_to_slave(output)?;
 
         // SR
-        self.i2c_start()?;
+        self.raw_i2c_start()?;
 
         // SAD + R
         self.i2c_write_byte((addr << 1) | 0x1)?;
         self.check_ack()?;
 
-        self.read_from_slave(input)?;
+        self.raw_read_from_slave(input)?;
 
         // SP
-        self.i2c_stop()
+        self.raw_i2c_stop()
     }
 }

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -89,7 +89,12 @@ where
         I2cBB { scl, sda, clk }
     }
 
-    fn i2c_start(&mut self) -> Result<(), crate::i2c::Error<E>> {
+    /// Send a raw I2C start.
+    ///
+    /// **This is a low-level control function.** For normal I2C devices,
+    /// please use the embedded-hal traits [Read], [Write], or
+    /// [WriteRead].
+    pub fn i2c_start(&mut self) -> Result<(), crate::i2c::Error<E>> {
         self.set_scl_high()?;
         self.set_sda_high()?;
         self.wait_for_clk();
@@ -103,7 +108,12 @@ where
         Ok(())
     }
 
-    fn i2c_stop(&mut self) -> Result<(), crate::i2c::Error<E>> {
+    /// Send a raw I2C stop.
+    ///
+    /// **This is a low-level control function.** For normal I2C devices,
+    /// please use the embedded-hal traits [Read], [Write], or
+    /// [WriteRead].
+    pub fn i2c_stop(&mut self) -> Result<(), crate::i2c::Error<E>> {
         self.set_scl_high()?;
         self.wait_for_clk();
 
@@ -181,8 +191,13 @@ where
         Ok(())
     }
 
+    /// Read raw bytes from the slave.
+    ///
+    /// **This is a low-level control function.** For normal I2C devices,
+    /// please use the embedded-hal traits [Read], [Write], or
+    /// [WriteRead].
     #[inline]
-    fn read_from_slave(&mut self, input: &mut [u8]) -> Result<(), crate::i2c::Error<E>> {
+    pub fn read_from_slave(&mut self, input: &mut [u8]) -> Result<(), crate::i2c::Error<E>> {
         for i in 0..input.len() {
             let should_send_ack = i != (input.len() - 1);
             input[i] = self.i2c_read_byte(should_send_ack)?;
@@ -190,8 +205,13 @@ where
         Ok(())
     }
 
+    /// Send raw bytes to the slave.
+    ///
+    /// **This is a low-level control function.** For normal I2C devices,
+    /// please use the embedded-hal traits [Read], [Write], or
+    /// [WriteRead].
     #[inline]
-    fn write_to_slave(&mut self, output: &[u8]) -> Result<(), crate::i2c::Error<E>> {
+    pub fn write_to_slave(&mut self, output: &[u8]) -> Result<(), crate::i2c::Error<E>> {
         for byte in output {
             self.i2c_write_byte(*byte)?;
             self.check_ack()?;


### PR DESCRIPTION
Hello!

I'm trying to talk to a [Beken BK1080](https://www.bekencorp.com/en/goods/detail/cid/34.html) FM receiver. This chip claims to speak I2C, but it's *not quite* exactly right. It uses the same pins and the same signaling, but the order is slightly different from a normal I2C transaction. It can share the I2C bus with other, "real" I2C devices just fine.

This seems like exactly the right use-case for a bit-bang I2C implementation, but I needed to expose a few of the previously private methods on `I2cBB` to make it work. I've added documentation comments with a strong warning that these are low-level calls, and to prefer the embedded-hal traits.

I can understand you might be reluctant to expose these methods, but I think I2C is sufficiently messy and unstandardized that it's worth a modest API change to talk to these devices. Otherwise, I would have to copy and paste the bitbang-hal source into my crate. I'd rather make these changes here so everybody can benefit.

Please let me know if there are any changes I can make to get this merged.